### PR TITLE
Fix the display of inline arglist

### DIFF
--- a/le-lisp.el
+++ b/le-lisp.el
@@ -78,30 +78,61 @@
           (set-window-configuration wnd)
           conn))))
 
+(defun lispy--find-lisp-package (package-name)
+  "Return either a CL expression to find the given package, or if
+PACKAGE-NAME is nil the package we found in the Lisp buffer."
+  (let ((package-via-buffer
+         (upcase (string-replace
+                  "#:" ""
+                  (if (lispy--use-sly-p)
+                      (sly-current-package)
+                    (slime-current-package))))))
+    (if (null package-name)
+        package-via-buffer
+      ;; The package local nickname is either defined in our current package or
+      ;; from a different "home package". In case of the latter we can simply
+      ;; rely on `cl:define-package' to figure it out for us. Note that we use
+      ;; `cl:ignore-errors' for when a package either can't be found or might
+      ;; not have been loaded yet.
+      `(cl:or (cl:ignore-errors
+               (,(if (lispy--use-sly-p) 'slynk-backend:find-locally-nicknamed-package
+                   'swank/backend:find-locally-nicknamed-package)
+                ,(upcase package-name)
+                (cl:find-package ,package-via-buffer)))
+              (cl:find-package ,(upcase package-name))))))
+
 (defun lispy--lisp-args (symbol)
   "Return a pretty string with arguments for SYMBOL."
-  (let ((args
-         (list
-          (mapconcat
-           #'prin1-to-string
-           (read (lispy--eval-lisp
-                  (format (if (lispy--use-sly-p)
-                              "(slynk-backend:arglist #'%s)"
-                            "(swank-backend:arglist #'%s)")
-                          symbol)))
-           " "))))
-    (if (listp args)
-        (format
-         "(%s %s)"
-         (propertize symbol 'face 'lispy-face-hint)
-         (mapconcat
-          #'identity
-          (mapcar (lambda (x) (propertize (downcase x)
-                                          'face 'lispy-face-req-nosel))
-                  args)
-          (concat "\n"
-                  (make-string (+ 2 (length symbol)) ?\ ))))
-      (propertize args 'face 'lispy-face-hint))))
+  (if-let* ((lisp-arglist
+             (if (lispy--use-sly-p)
+                 (sly-eval
+                  `(slynk:operator-arglist
+                    ,(sly-cl-symbol-name symbol)
+                    ,(lispy--find-lisp-package (sly-cl-symbol-package symbol))))
+               (slime-eval
+                `(swank:operator-arglist
+                  ,(slime-cl-symbol-name symbol)
+                  ,(lispy--find-lisp-package (slime-cl-symbol-package symbol))))))
+            (args (list (mapconcat #'prin1-to-string (read lisp-arglist) " "))))
+      (let* ((symbol-package (if (lispy--use-sly-p) (sly-cl-symbol-package symbol)
+                               (slime-cl-symbol-package symbol)))
+             (package-prefixed-arglist (format "(%s:" symbol-package)))
+        ;; In Lisp, it is often the case we prefix low level packages with a `%'
+        ;; symbol. This is problematic in Elisp with `format'. For example, `%g'
+        ;; can have special meaning. We can eliminate this edge case by always
+        ;; concatenating.
+        (concat
+         (if symbol-package package-prefixed-arglist "(")
+         (format "%s"
+                 (mapconcat
+                  #'identity
+                  (mapcar (lambda (x)
+                            (propertize (downcase x)
+                                        'face 'lispy-face-req-nosel))
+                          args)
+                  (concat "\n" (make-string (+ 2 (length symbol)) ?\ ))))
+         ")"))
+    (format "Could not find symbol %s" (upcase symbol))))
 
 (defun lispy--lisp-describe (symbol)
   "Return documentation for SYMBOL."


### PR DESCRIPTION
This fixes up the display of the inline arglist for Lisp (Slime and Sly) via the `C-2` keybinding. Before, symbols would be very cluttered with unnecessary package prefixes and were not aware of package local nicknames. You would also get an error if you tried to get the arglist for a macro. Tested on both Sly and Slime but the patch probably needs some style review as I don't write a ton of elisp.

Before:
![2024-09-25__04:06:50](https://github.com/user-attachments/assets/7a51adef-31b1-40b7-9372-9620b670062d)

After:
![2024-09-25__04:07:18](https://github.com/user-attachments/assets/4a5507c7-4151-4396-b68f-ec0d6d17caab)

Here is a package local nickname defined in my current package being successfully displayed:
![2024-09-25__10:33:59](https://github.com/user-attachments/assets/c25b9c6b-dc25-490c-82fd-84eb0e814bc5)

And here is a package local nickname but it's a nickname not defined in my package but a different home package:
![2024-09-25__10:34:38](https://github.com/user-attachments/assets/dc862e13-b4ee-41e0-a95a-dd7f68058ed7)
