### PR TITLE
minimal janet execution with ajrepl

### DIFF
--- a/le-janet.el
+++ b/le-janet.el
@@ -1,0 +1,37 @@
+;;; le-janet.el --- Description -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2025  John Bonini
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;;  Description
+;;
+;;; Code:
+
+(require 'janet-mode)                   ;; janet-ts-mode?
+(require 'ajrepl)
+
+(declare-function ajrepl-trim-trailing-newline-maybe "ext:ajrepl")
+(declare-function ajrepl-get-process "ext:ajrepl")
+
+(defun lispy--eval-janet (code-str)
+  "Eval CODE-STR as janet code. Return repl output."
+  (with-current-buffer ajrepl-repl-buffer-name
+    (goto-char (point-max))
+    (insert (ajrepl-trim-trailing-newline-maybe code-str))
+    (comint-send-input)
+    (let ((command-output-begin (point))
+          (response-timeout 5))
+      (while (null (save-excursion
+                     (let ((inhibit-field-text-motion t))
+                       (goto-char command-output-begin)
+                       (re-search-forward "^repl:[0-9]*:> " nil t))))
+        (accept-process-output (ajrepl-get-process) response-timeout)
+        (goto-char (point-max)))
+      (goto-char (point-max))
+      (buffer-substring-no-properties command-output-begin (line-end-position 0)))))
+
+(provide 'le-janet)
+;;; le-janet.el ends here

--- a/lispy.el
+++ b/lispy.el
@@ -4221,7 +4221,9 @@ SYMBOL is a string."
     (lisp-mode
      le-lisp lispy--eval-lisp)
     (hy-mode
-     le-hy lispy--eval-hy)))
+     le-hy lispy--eval-hy)
+    (janet-mode                         ;; janet-ts-mode?
+     le-janet lispy--eval-janet)))
 
 (defvar lispy-eval-output nil
   "The eval function may set this when there's output.")


### PR DESCRIPTION
This adds support for repl evaluation for [janet](https://janet-lang.org/) using [ajrepl](https://github.com/sogaiu/ajrepl).

Some janet support was already in lispy, but repl evaluation was never implemented.

Currently this requires janet-mode (the major mode lispy uses to know what eval function to call) and for ajrepl-interaction-mode to be enabled.
One must also start a janet repl by calling M-x ajrepl.

This is a pretty minimal implementation I just hacked together and figured I'd share, so I'm just submitting as a draft PR. I may update this if I notice any major issues while using in my personal config. Any feedback is appreciated. Though I wouldn't object to just merging as is.