### PR TITLE
Adjust lispy to changes in Emacs and Org-mode internals

### DIFF
--- a/le-python.el
+++ b/le-python.el
@@ -298,8 +298,8 @@ it at one time."
 (defvar lispy--python-init-file nil)
 
 (defun lispy--python-poetry-name ()
-  (let ((pyproject
-         (file-name-directory (locate-dominating-file (buffer-file-name) "pyproject.toml"))))
+  (when-let* ((root (locate-dominating-file (buffer-file-name) "pyproject.toml"))
+              (pyproject (file-name-directory root)))
     (and (file-exists-p pyproject)
          (not (equal python-shell-interpreter "python"))
          (with-current-buffer (find-file-noselect pyproject)

--- a/le-python.el
+++ b/le-python.el
@@ -298,7 +298,8 @@ it at one time."
 (defvar lispy--python-init-file nil)
 
 (defun lispy--python-poetry-name ()
-  (when-let* ((root (locate-dominating-file (buffer-file-name) "pyproject.toml"))
+  (when-let* ((bfn (buffer-file-name))
+              (root (locate-dominating-file bfn "pyproject.toml"))
               (pyproject (file-name-directory root)))
     (and (file-exists-p pyproject)
          (not (equal python-shell-interpreter "python"))

--- a/le-python.el
+++ b/le-python.el
@@ -298,7 +298,8 @@ it at one time."
 (defvar lispy--python-init-file nil)
 
 (defun lispy--python-poetry-name ()
-  (let ((pyproject (expand-file-name "pyproject.toml" (counsel-locate-git-root))))
+  (let ((pyproject
+         (file-name-directory (locate-dominating-file (buffer-file-name) "pyproject.toml"))))
     (and (file-exists-p pyproject)
          (not (equal python-shell-interpreter "python"))
          (with-current-buffer (find-file-noselect pyproject)

--- a/le-python.el
+++ b/le-python.el
@@ -300,7 +300,7 @@ it at one time."
 (defun lispy--python-poetry-name ()
   (when-let* ((bfn (buffer-file-name))
               (root (locate-dominating-file bfn "pyproject.toml"))
-              (pyproject (file-name-directory root)))
+              (pyproject (expand-file-name "pyproject.toml" root)))
     (and (file-exists-p pyproject)
          (not (equal python-shell-interpreter "python"))
          (with-current-buffer (find-file-noselect pyproject)
@@ -357,7 +357,8 @@ it at one time."
              (buffer
               (let ((python-shell-completion-native-enable nil)
                     (default-directory (if poetry-name
-                                           (counsel-locate-git-root)
+                                           (expand-file-name
+                                            (project-root (project-current)))
                                          default-directory)))
                 (python-shell-make-comint
                  python-binary-name proc-name nil nil))))

--- a/lispy.el
+++ b/lispy.el
@@ -7640,42 +7640,48 @@ Defaults to `error'."
 (defun lispy--function-parse (str)
   "Extract the function body and args from it's expression STR."
   (let ((body (lispy--read str))
-        args)
-    (cond ((eq (car body) 'lambda)
-           (setq body (cons 'defun body)))
-          ((eq (car body) 'closure)
-           (setq body `(defun noname ,@(cddr body))))
-          ((eq (car body) 'defsubst)
-           (setq body (cons 'defun (cdr body)))))
-    (cond ((memq (car body) '(defun defmacro))
-           (setq body (lispy--whitespace-trim (cdr body))))
-          ((eq (car body) 'defalias)
-           (let ((name (cadr (cadr (read str)))))
-             (setq body
-                   (cons name (cdr (symbol-function name))))))
-          (t
-           (error "Expected defun, defmacro, or defalias got %s" (car body))))
-    (if (symbolp (car body))
-        (setq body (lispy--whitespace-trim (cdr body)))
-      (error "Expected function name, got %s" (car body)))
-    (if (listp (car body))
-        (progn
-          (setq args (car body))
+	args)
+    (if (not (consp body))
+        (progn (setq args (aref body 0))
+               (setq body (aref body 1)))
+      ;; In Emacs 30, `read' returns a dedicated type, instead of
+      ;; simple list, for lambdas, defuns, closures, etc.  And code
+      ;; below is only valid for `defmacro'.  Keep it for Emacs < 30.
+      (cond ((eq (car body) 'lambda)
+             (setq body (cons 'defun body)))
+            ((eq (car body) 'closure)
+             (setq body `(defun noname ,@(cddr body))))
+            ((eq (car body) 'defsubst)
+             (setq body (cons 'defun (cdr body)))))
+      (cond ((memq (car body) '(defun defmacro))
+             (setq body (lispy--whitespace-trim (cdr body))))
+            ((eq (car body) 'defalias)
+             (let ((name (cadr (cadr (read str)))))
+               (setq body
+                     (cons name (cdr (symbol-function name))))))
+            (t
+             (error "Expected defun, defmacro, or defalias got %s" (car body))))
+      (if (symbolp (car body))
+          (setq body (lispy--whitespace-trim (cdr body)))
+        (error "Expected function name, got %s" (car body)))
+      (if (listp (car body))
+          (progn
+            (setq args (car body))
+            (setq body (lispy--whitespace-trim (cdr body))))
+        (error "Expected function arguments, got %s" (car body)))
+      ;; skip docstring
+      (if (and (listp (car body))
+               (eq (caar body) 'ly-raw)
+               (eq (cadar body) 'string))
           (setq body (lispy--whitespace-trim (cdr body))))
-      (error "Expected function arguments, got %s" (car body)))
-    ;; skip docstring
-    (if (and (listp (car body))
-             (eq (caar body) 'ly-raw)
-             (eq (cadar body) 'string))
-        (setq body (lispy--whitespace-trim (cdr body))))
-    ;; skip declare
-    (if (and (listp (car body))
-             (eq (caar body) 'declare))
-        (setq body (lispy--whitespace-trim (cdr body))))
-    ;; skip interactive
-    (if (and (listp (car body))
-             (eq (caar body) 'interactive))
-        (setq body (lispy--whitespace-trim (cdr body))))
+      ;; skip declare
+      (if (and (listp (car body))
+               (eq (caar body) 'declare))
+          (setq body (lispy--whitespace-trim (cdr body))))
+      ;; skip interactive
+      (if (and (listp (car body))
+               (eq (caar body) 'interactive))
+          (setq body (lispy--whitespace-trim (cdr body)))))
     (list args body)))
 
 (defun lispy--flatten-function (fstr e-args)

--- a/lispy.el
+++ b/lispy.el
@@ -6639,7 +6639,9 @@ Otherwise return cons of current string, symbol or list bounds."
              (org-back-to-heading t)
              (point))
            (progn
-             (org-end-of-subtree t t)
+             (outline-mark-subtree)
+             (exchange-point-and-mark)
+             (deactivate-mark)
              (when (and (org-at-heading-p)
                         (not (eobp)))
                (backward-char 1))


### PR DESCRIPTION
- Adjust `lispy` to changes in Emacs internals (cae6554d6e95b3f7a3dbf9d85ba396edd8412543).
- Adjust `lispy` to changes in Org-mode (b41e40744a4d1a06482db9b3e6dd43b63cf9abb8).
- Remove hard dependency from `counsel`, use built-in functions instead.

Please, see more context in each commit message.

It makes all tests pass on Emacs 30.